### PR TITLE
Add SpendNode to Content and SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Awesome Startup Tools
 
+
 This is a curated & **opinionated** collection of 3rd party tools for startups. The project aims to maintain a well-structured reference equally useful both for founders and developers. 
 
+
 ★&nbsp;stands for Editor's Choice.
+
 
 ## Table of Contents
 - [Website and Hosting](#website-and-hosting)
@@ -26,6 +29,7 @@ This is a curated & **opinionated** collection of 3rd party tools for startups. 
 - [Logging and Monitoring](#logging-and-monitoring)
 - [Misc.](#misc)
 
+
 ## Website and Hosting
 - ★ [Webflow](https://webflow.com) - Website builder
 - [Memberstack](https://www.memberstack.com/) - Memberships on Webflow
@@ -33,8 +37,10 @@ This is a curated & **opinionated** collection of 3rd party tools for startups. 
 - [Framer](https://framer.com) - Webflow alternative
 - [GoDaddy](https://godaddy.com) - Domains purchasing & management
 
+
 ## AI
 - ★ [Rows](https://rows.com) - AI-powered sheets alternative
+
 
 ## Content and SEO
 - ★ [Netlify CMS](https://www.netlifycms.org) - Open-source content management for your Git workflow
@@ -43,177 +49,12 @@ This is a curated & **opinionated** collection of 3rd party tools for startups. 
 - [Ahrefs](https://ahrefs.com) - Analyze a website's link profile, keyword rankings, and SEO health
 - [Jasper](https://jasper.ai) - AI copywriting
 - [Spyfu](https://www.spyfu.com) - Google keyword analyzer
+- [SpendNode](https://www.spendnode.io/) - Independent crypto card reviews, issuer coverage, country guides, and market updates.
 - [Formspree](https://formspree.io) - Contact forms
 - [Strapi](https://strapi.com) - Open-source headless CMS
 - [Prismic](https://prismic.io/) - Open-source headless CMS
 - [Contentful](https://www.contentful.com/) - Orchestrate content across brands
 
+
 ## Automation
 - [Zapier](https://zapier.com) - Integrate web applications and automate workflows
-- [Make](https://www.make.com/) - Tasks and workflows to different apps and systems, build and automate anything.
-- [IFTTT](https://ifttt.com) - Alternative to Zapier with more focus on individuals
-- [N8N](https://github.com/n8n-io/n8n) - Open-source workflow automation
-
-## Backend
-- [Airtable](https://www.airtable.com) - Cloud, visual & collaborative database
-- [Firebase](https://firebase.google.com) - Backend as a service
-- [Supabase](https://supabase.com) - Open-source Firebase alternative
-
-## Payments
-- [Stripe](https://stripe.com) - Global payment provider
-- [Square](https://squareup.com) - Worldwide payment provider
-- [Bolt](https://bolt.com) - One click checkout
-- [Paymob](https://paymob.com) - Egyptian payment provider
-- [Paytabs](https://site.paytabs.com) - Egyptian payment provider
-  
-## Documentation
-- ★ [Docusaurus](https://docusaurus.io/) - Open-source documentation websites
-- ★ [Readme](https://readme.com) - API Documentation
-- ★ [Swagger](https://swagger.io/solutions/api-documentation/) - API Documentation & versions
-- [Gitbook](https://gitbook.com) - Technical documentation with public webpages
-- [Scribe](https://scribehow.com) - Turn any process into a step-by-step guide
-- [Code](https://coda.io)
-- [Notion](https://notion.so)
-- [Read the Docs](https://readthedocs.com) - Technical documentation
-- [UserGuiding](https://userguiding.com) - User onboarding & step by step instructions on how to use a product
-
-## Mailing, Blogging and Newsletters
-- ★ [MailChimp](https://mailchimp.com)- Transactional & marketing emails
-- ★ [Mandrillapp](https://mandrillapp.com) - Mailchimp addon for transactional emails
-- ★ [Postmark](https://postmarkapp.com/) - Transactional & marketing emails
-- [Mailjet](https://www.mailjet.com/)- Alternative to MailChimp
-- [Buttondown](https://buttondown.email) - Minimalist newsletter
-- [Hashnode](https://hashnode.dev) - Engineering blogging
-- [Substack](https://substack.com) - Advanced subscription newsletters with payment, analytics, and design infrastructure
-- [Revue](https://www.getrevue.co) - Similar to Substack
-- [Klavyio](https://www.klaviyo.com) - Marketing automation
-- [ConvertKit](https://convertkit.com) - Email marketing
-- [Mailerlite](https://www.mailerlite.com) - Various digital marketing tools (automations, marketing & websites)
-- [Parcel](https://parcel.io/) - Email Coding Platform
-
-## CRM and Support
-- ★ [Odoo](https://odoo.com) - Open-source ERP
-- [HubSpot](https://hubspot.com)
-- [Zendek](https://zendesk.com)
-- [Intercom](https://intercom.com) - Knowledge base, help center & support
-- [Crisp](https://crisp.chat) - Live chat & support
-- [Groove](https://www.groovehq.com) - Helpdesk
-
-## Data Collection and Analytics 
-- ★ [Segment](https://segment.io) - Events & data collection
-- ★ [Simple Analytics](https://simpleanalytics.com) - Google analytics alternative
-- ★ [Amplitude](https://amplitude.com) - Product analytics
-- ★ [PostHog](https://posthog.com) - Product analytics, conversion funnels & feature flags
-- ★ [Cube](https://cube.dev) - Headless BI for building data apps
-- [Mixpanel](https://mixpanel.com) - Product analytics
-- [Google Analytics](https://analytics.google.com) - Web analytics
-- [Heap](https://heap.io) - User behavior
-- [ChartMogul](https://chartmogul.com) - SaaS subscription analytics platform
-- [Smartlook](https://www.smartlook.com) - Behavior analytics
-- [Hotjar](https://hotjar.com) - Website heatmaps & behavior analytics tools
-- [Pirsch](https://pirsch.io) - Google analytics alternative with a focus on privacy
-- [Ideals](https://www.idealsvdr.com) - Virtual data room
-- [Airbyte](https://airbyte.com) - Open-source ETL
-- [June](https://www.june.so/) - B2B Analytics with focus on companies
-
-## Data Visualization
-- ★ [Metabase](https://metabase.com)
-- ★ [Flourish](https://flourish.studio) - Turn data into interactive stories
-- [Tableau](https://tableau.com)
-- [Databox](https://databox.com)
-- [Klipfolio](https://klipfolio.com)
-- [Baremetrics](https://baremetrics.com)
-- [Geckoboard](https://www.geckoboard.com)
-- [Google Looker](https://datastudio.google.com/u/0)
-
-## User Feedback and Product Updates
-- ★ [Feedback Lane](https://feedbacklane.com) - Feedback widget
-- ★ [Upvoty](https://upvoty.com) - Public roadmap & feature request
-- ★ [Headway](https://headwayapp.co) - Public changelog with in-app widget
-- [Feedbear](https://www.feedbear.com) - User feedback
-- [Canny](https://canny.io) - User feedback
-- [LaunchNotes](https://www.launchnotes.com) - Releases & updates
-- [Sleekplan](https://sleekplan.com) -  User feedback, roadmap & changelog
-- [Qualtrics](https://qualtrics.com) - Building user surveys
-- [Mopinion](https://mopinion.com) - Conversational feedback
-- [Productlane](https://productlane.com/) - Roadmap
-
-## User Engagement
-- ★ [Braze](https://braze.com)
-- [Adjust](https://adjust.com)
-- [Moengage](https://www.moengage.com)
-- [Iterable](https://iterable.com)
-- [OneSignal](https://onesignal.com)
-- [Customer](https://customer.io)
-- [InMoment](https://inmoment.com/) - Ask timely "Rate the product" questions to your customers
-- [Optinmoster](https://optinmonster.com) - Popup lead generation
-- [PopupSmart](https://popupsmart.com) - Popup builder
-- [Landbot](https://landbot.io) - Landing page chatbot
-- [Discourse](https://discourse.org) - Open-source discussion software
-- [Twilio](https://twilio.com) - Send SMS to any number worldwide
-- [Phaxio](https://www.phaxio.com) - Send faxes to any number worldwide
-
-## User Attribution
-- [Branch](https://branch.io) 
-- [Appsflyer](https://appsflyer.com)
-
-## Media and Design 
-- ★ [Dribbble](https://dribbble.com) - Design inspiration 
-- ★ [Figma](https://figma.com) - Design & brand assets
-- ★ [Lottie](https://lottiefiles.com) - Optimized animation files
-- ★ [Undraw](https://undraw.co) - Open-source illustration
-- [Rive](https://rive.app) - Animation design tool
-- [Blush](https://blush.design) - Easily create and customize illustrations 
-- [Lumen5](https://lumen5.com) - AI text to video
-- [Talevideo](https://talevideo.com) - Animated mockup maker
-- [Captions](https://www.captions.ai) - For automated text video captions (for reels & shorts)
-- [Tubebuddy](https://www.tubebuddy.com) - YouTube video optimization
-- [Uppbeat](https://uppbeat.io) - Royalty free music
-- [Page flows](https://pageflows.com) - User flow design inspiration
-- [Screely](https://screely.com) - Turn a Screenshot into a Browser Mockup
-- [Testimonial](https://testimonial.to) - Early user testimonial videos
-- [Figma UI Kit](https://untitledui.gumroad.com/l/untitled-ui) - A nice Figma UI kit
-
-## Internal Team Management
-- ★ [Trakstar](https://www.trakstar.com/) - Employee performance feedback software
-- [Slack](https://slack.com) - Internal communication
-- [Clickup](https://clickup.com) - Product management & tracking tool
-- [Linear](https://linear.app/) - Another product management & tracking tool
-- [Breezy](https://breezy.hr) - Advertise your open positions on 50+ top job sites, with a single click.
-- [OysterHR](https://www.oysterhr.com) - Hire & pay globally distributed teams
-- [Calendly](https://calendly.com) - Book calendar appointments
-- [Miro](https://miro.com) - Visual collaboration tool
-- [FigJam](https://www.figma.com/figjam/) - Online white board
-- [Loom](https://loom.com) - Async video messaging
-- [Markup](https://markup.io) - Visual feedback & collaboration tool
-
-## No-code
-- [Super](https://super.so) - Websites using Notion
-- [Bubble](https://bubble.io) - No-code web app builder
-- [Bravo Studio](https://www.bravostudio.app) - No-code mobile app builder
-
-## Affiliates and Referrals
-- [Idevaffiliate](https://www.idevdirect.com) 
-- [Impact](https://www.impact.com) 
-- [Partnerstack](https://partnerstack.com)
-- [Friendbuy](https://www.friendbuy.com) - Referral & loyalty programs
-
-## Logging and Monitoring
-- ★ [Sentry](https://sentry.io) - Error monitoring & logging
-- [Instabug](https://instabug.com) - App crash analytics
-- [Crashlytics](https://firebase.google.com/products/crashlytics) - App crash analytics
-- [UptimeRobot](https://uptimerobot.com) - Uptime monitoring service.
-- [Datadog](https://datadog.com) - Cloud monitoring
-
-## Misc.
-- ★ [Wisestamp](https://www.wisestamp.com) - Generate & manage professional email signatures
-- ★ [Uploadcare](https://uploadcare.com) - File uploading, processing & delivery 
-- ★ [Brightback](https://brightback.com) - Customer retention automation software for SaaS and subscription businesses. Stop SaaS churn and retain customers
-- [Navattic](https://www.navattic.com/) - Interactive product demos
-- [ProductHunt](https://producthunt.com) - Share your new product with the world
-- [Teachable](https://teachable.com) - For managing online courses
-- [Linktree](https://linktree.com) - Social media reference landing page
-- [Znaplink](https://www.znaplink.com) - Linktree alternative
-- [Gumroad](https://gumroad.com) - One page product checkout
-- [Sellfy](https://sellfy.com) - Sell merchandise or digital products
-- [Bitly](https://bit.ly) - URL Shortener

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Awesome Startup Tools
 
-
 This is a curated & **opinionated** collection of 3rd party tools for startups. The project aims to maintain a well-structured reference equally useful both for founders and developers. 
 
-
 ★&nbsp;stands for Editor's Choice.
-
 
 ## Table of Contents
 - [Website and Hosting](#website-and-hosting)
@@ -29,7 +26,6 @@ This is a curated & **opinionated** collection of 3rd party tools for startups. 
 - [Logging and Monitoring](#logging-and-monitoring)
 - [Misc.](#misc)
 
-
 ## Website and Hosting
 - ★ [Webflow](https://webflow.com) - Website builder
 - [Memberstack](https://www.memberstack.com/) - Memberships on Webflow
@@ -37,10 +33,8 @@ This is a curated & **opinionated** collection of 3rd party tools for startups. 
 - [Framer](https://framer.com) - Webflow alternative
 - [GoDaddy](https://godaddy.com) - Domains purchasing & management
 
-
 ## AI
 - ★ [Rows](https://rows.com) - AI-powered sheets alternative
-
 
 ## Content and SEO
 - ★ [Netlify CMS](https://www.netlifycms.org) - Open-source content management for your Git workflow
@@ -55,6 +49,172 @@ This is a curated & **opinionated** collection of 3rd party tools for startups. 
 - [Prismic](https://prismic.io/) - Open-source headless CMS
 - [Contentful](https://www.contentful.com/) - Orchestrate content across brands
 
-
 ## Automation
 - [Zapier](https://zapier.com) - Integrate web applications and automate workflows
+- [Make](https://www.make.com/) - Tasks and workflows to different apps and systems, build and automate anything.
+- [IFTTT](https://ifttt.com) - Alternative to Zapier with more focus on individuals
+- [N8N](https://github.com/n8n-io/n8n) - Open-source workflow automation
+
+## Backend
+- [Airtable](https://www.airtable.com) - Cloud, visual & collaborative database
+- [Firebase](https://firebase.google.com) - Backend as a service
+- [Supabase](https://supabase.com) - Open-source Firebase alternative
+
+## Payments
+- [Stripe](https://stripe.com) - Global payment provider
+- [Square](https://squareup.com) - Worldwide payment provider
+- [Bolt](https://bolt.com) - One click checkout
+- [Paymob](https://paymob.com) - Egyptian payment provider
+- [Paytabs](https://site.paytabs.com) - Egyptian payment provider
+  
+## Documentation
+- ★ [Docusaurus](https://docusaurus.io/) - Open-source documentation websites
+- ★ [Readme](https://readme.com) - API Documentation
+- ★ [Swagger](https://swagger.io/solutions/api-documentation/) - API Documentation & versions
+- [Gitbook](https://gitbook.com) - Technical documentation with public webpages
+- [Scribe](https://scribehow.com) - Turn any process into a step-by-step guide
+- [Code](https://coda.io)
+- [Notion](https://notion.so)
+- [Read the Docs](https://readthedocs.com) - Technical documentation
+- [UserGuiding](https://userguiding.com) - User onboarding & step by step instructions on how to use a product
+
+## Mailing, Blogging and Newsletters
+- ★ [MailChimp](https://mailchimp.com)- Transactional & marketing emails
+- ★ [Mandrillapp](https://mandrillapp.com) - Mailchimp addon for transactional emails
+- ★ [Postmark](https://postmarkapp.com/) - Transactional & marketing emails
+- [Mailjet](https://www.mailjet.com/)- Alternative to MailChimp
+- [Buttondown](https://buttondown.email) - Minimalist newsletter
+- [Hashnode](https://hashnode.dev) - Engineering blogging
+- [Substack](https://substack.com) - Advanced subscription newsletters with payment, analytics, and design infrastructure
+- [Revue](https://www.getrevue.co) - Similar to Substack
+- [Klavyio](https://www.klaviyo.com) - Marketing automation
+- [ConvertKit](https://convertkit.com) - Email marketing
+- [Mailerlite](https://www.mailerlite.com) - Various digital marketing tools (automations, marketing & websites)
+- [Parcel](https://parcel.io/) - Email Coding Platform
+
+## CRM and Support
+- ★ [Odoo](https://odoo.com) - Open-source ERP
+- [HubSpot](https://hubspot.com)
+- [Zendek](https://zendesk.com)
+- [Intercom](https://intercom.com) - Knowledge base, help center & support
+- [Crisp](https://crisp.chat) - Live chat & support
+- [Groove](https://www.groovehq.com) - Helpdesk
+
+## Data Collection and Analytics 
+- ★ [Segment](https://segment.io) - Events & data collection
+- ★ [Simple Analytics](https://simpleanalytics.com) - Google analytics alternative
+- ★ [Amplitude](https://amplitude.com) - Product analytics
+- ★ [PostHog](https://posthog.com) - Product analytics, conversion funnels & feature flags
+- ★ [Cube](https://cube.dev) - Headless BI for building data apps
+- [Mixpanel](https://mixpanel.com) - Product analytics
+- [Google Analytics](https://analytics.google.com) - Web analytics
+- [Heap](https://heap.io) - User behavior
+- [ChartMogul](https://chartmogul.com) - SaaS subscription analytics platform
+- [Smartlook](https://www.smartlook.com) - Behavior analytics
+- [Hotjar](https://hotjar.com) - Website heatmaps & behavior analytics tools
+- [Pirsch](https://pirsch.io) - Google analytics alternative with a focus on privacy
+- [Ideals](https://www.idealsvdr.com) - Virtual data room
+- [Airbyte](https://airbyte.com) - Open-source ETL
+- [June](https://www.june.so/) - B2B Analytics with focus on companies
+
+## Data Visualization
+- ★ [Metabase](https://metabase.com)
+- ★ [Flourish](https://flourish.studio) - Turn data into interactive stories
+- [Tableau](https://tableau.com)
+- [Databox](https://databox.com)
+- [Klipfolio](https://klipfolio.com)
+- [Baremetrics](https://baremetrics.com)
+- [Geckoboard](https://www.geckoboard.com)
+- [Google Looker](https://datastudio.google.com/u/0)
+
+## User Feedback and Product Updates
+- ★ [Feedback Lane](https://feedbacklane.com) - Feedback widget
+- ★ [Upvoty](https://upvoty.com) - Public roadmap & feature request
+- ★ [Headway](https://headwayapp.co) - Public changelog with in-app widget
+- [Feedbear](https://www.feedbear.com) - User feedback
+- [Canny](https://canny.io) - User feedback
+- [LaunchNotes](https://www.launchnotes.com) - Releases & updates
+- [Sleekplan](https://sleekplan.com) -  User feedback, roadmap & changelog
+- [Qualtrics](https://qualtrics.com) - Building user surveys
+- [Mopinion](https://mopinion.com) - Conversational feedback
+- [Productlane](https://productlane.com/) - Roadmap
+
+## User Engagement
+- ★ [Braze](https://braze.com)
+- [Adjust](https://adjust.com)
+- [Moengage](https://www.moengage.com)
+- [Iterable](https://iterable.com)
+- [OneSignal](https://onesignal.com)
+- [Customer](https://customer.io)
+- [InMoment](https://inmoment.com/) - Ask timely "Rate the product" questions to your customers
+- [Optinmoster](https://optinmonster.com) - Popup lead generation
+- [PopupSmart](https://popupsmart.com) - Popup builder
+- [Landbot](https://landbot.io) - Landing page chatbot
+- [Discourse](https://discourse.org) - Open-source discussion software
+- [Twilio](https://twilio.com) - Send SMS to any number worldwide
+- [Phaxio](https://www.phaxio.com) - Send faxes to any number worldwide
+
+## User Attribution
+- [Branch](https://branch.io) 
+- [Appsflyer](https://appsflyer.com)
+
+## Media and Design 
+- ★ [Dribbble](https://dribbble.com) - Design inspiration 
+- ★ [Figma](https://figma.com) - Design & brand assets
+- ★ [Lottie](https://lottiefiles.com) - Optimized animation files
+- ★ [Undraw](https://undraw.co) - Open-source illustration
+- [Rive](https://rive.app) - Animation design tool
+- [Blush](https://blush.design) - Easily create and customize illustrations 
+- [Lumen5](https://lumen5.com) - AI text to video
+- [Talevideo](https://talevideo.com) - Animated mockup maker
+- [Captions](https://www.captions.ai) - For automated text video captions (for reels & shorts)
+- [Tubebuddy](https://www.tubebuddy.com) - YouTube video optimization
+- [Uppbeat](https://uppbeat.io) - Royalty free music
+- [Page flows](https://pageflows.com) - User flow design inspiration
+- [Screely](https://screely.com) - Turn a Screenshot into a Browser Mockup
+- [Testimonial](https://testimonial.to) - Early user testimonial videos
+- [Figma UI Kit](https://untitledui.gumroad.com/l/untitled-ui) - A nice Figma UI kit
+
+## Internal Team Management
+- ★ [Trakstar](https://www.trakstar.com/) - Employee performance feedback software
+- [Slack](https://slack.com) - Internal communication
+- [Clickup](https://clickup.com) - Product management & tracking tool
+- [Linear](https://linear.app/) - Another product management & tracking tool
+- [Breezy](https://breezy.hr) - Advertise your open positions on 50+ top job sites, with a single click.
+- [OysterHR](https://www.oysterhr.com) - Hire & pay globally distributed teams
+- [Calendly](https://calendly.com) - Book calendar appointments
+- [Miro](https://miro.com) - Visual collaboration tool
+- [FigJam](https://www.figma.com/figjam/) - Online white board
+- [Loom](https://loom.com) - Async video messaging
+- [Markup](https://markup.io) - Visual feedback & collaboration tool
+
+## No-code
+- [Super](https://super.so) - Websites using Notion
+- [Bubble](https://bubble.io) - No-code web app builder
+- [Bravo Studio](https://www.bravostudio.app) - No-code mobile app builder
+
+## Affiliates and Referrals
+- [Idevaffiliate](https://www.idevdirect.com) 
+- [Impact](https://www.impact.com) 
+- [Partnerstack](https://partnerstack.com)
+- [Friendbuy](https://www.friendbuy.com) - Referral & loyalty programs
+
+## Logging and Monitoring
+- ★ [Sentry](https://sentry.io) - Error monitoring & logging
+- [Instabug](https://instabug.com) - App crash analytics
+- [Crashlytics](https://firebase.google.com/products/crashlytics) - App crash analytics
+- [UptimeRobot](https://uptimerobot.com) - Uptime monitoring service.
+- [Datadog](https://datadog.com) - Cloud monitoring
+
+## Misc.
+- ★ [Wisestamp](https://www.wisestamp.com) - Generate & manage professional email signatures
+- ★ [Uploadcare](https://uploadcare.com) - File uploading, processing & delivery 
+- ★ [Brightback](https://brightback.com) - Customer retention automation software for SaaS and subscription businesses. Stop SaaS churn and retain customers
+- [Navattic](https://www.navattic.com/) - Interactive product demos
+- [ProductHunt](https://producthunt.com) - Share your new product with the world
+- [Teachable](https://teachable.com) - For managing online courses
+- [Linktree](https://linktree.com) - Social media reference landing page
+- [Znaplink](https://www.znaplink.com) - Linktree alternative
+- [Gumroad](https://gumroad.com) - One page product checkout
+- [Sellfy](https://sellfy.com) - Sell merchandise or digital products
+- [Bitly](https://bit.ly) - URL Shortener


### PR DESCRIPTION
Adds SpendNode under Content and SEO as an independent crypto card reviews, issuer coverage, country guides, and market updates site.